### PR TITLE
ZXingObjC como dependencia de Swift Package Manager

### DIFF
--- a/CovidApp/Cartfile
+++ b/CovidApp/Cartfile
@@ -1,1 +1,0 @@
-github "TheLevelUp/ZXingObjC" ~> 3.6

--- a/CovidApp/Cartfile.resolved
+++ b/CovidApp/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "TheLevelUp/ZXingObjC" "3.6.4"

--- a/CovidApp/CovidApp.xcodeproj/project.pbxproj
+++ b/CovidApp/CovidApp.xcodeproj/project.pbxproj
@@ -1941,7 +1941,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -1975,7 +1974,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -2112,7 +2110,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -2228,7 +2225,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -2344,7 +2340,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -2460,7 +2455,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -2570,7 +2564,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -2679,7 +2672,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -2788,7 +2780,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;
@@ -2897,7 +2888,6 @@
 				DEVELOPMENT_TEAM = AXB6T3Q6UZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/ExternalFrameworks",
 				);
 				INFOPLIST_FILE = CovidApp/Info.plist;

--- a/CovidApp/CovidApp.xcodeproj/project.pbxproj
+++ b/CovidApp/CovidApp.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		510311882446376A002780C8 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 510311872446376A002780C8 /* MapKit.framework */; };
 		516EAC1C243E8AF700344042 /* EscanearDniViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 516EAC1B243E8AF700344042 /* EscanearDniViewController.xib */; };
 		518C07AC244CD0CB0066E243 /* UbicacionFachada.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518C07AB244CD0CB0066E243 /* UbicacionFachada.swift */; };
-		51F2B361243F86E500ED16C0 /* ZXingObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51F2B360243F86E500ED16C0 /* ZXingObjC.framework */; };
 		51F2B367243FEBAE00ED16C0 /* EscanerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2B365243FEBAE00ED16C0 /* EscanerViewController.swift */; };
 		51F2B368243FEBAE00ED16C0 /* EscanerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51F2B366243FEBAE00ED16C0 /* EscanerViewController.xib */; };
 		51F2B36A2440BBCA00ED16C0 /* EscanearDniPresentador.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2B3692440BBCA00ED16C0 /* EscanearDniPresentador.swift */; };
@@ -215,6 +214,7 @@
 		E8E44DB724ACB99300E26044 /* InformacionPBAPresentador.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8E44DB624ACB99300E26044 /* InformacionPBAPresentador.swift */; };
 		FB01E299244783F600692E3C /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB01E298244783F600692E3C /* Array.swift */; };
 		FB05B0B124452DBD00CDA0CE /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB05B0B024452DBD00CDA0CE /* WebKit.framework */; };
+		FB0660212524FF1B00909C5C /* ZXingObjC in Frameworks */ = {isa = PBXBuildFile; productRef = FB0660202524FF1B00909C5C /* ZXingObjC */; };
 		FB6AF371251F7D000013B5D7 /* SwiftOTP in Frameworks */ = {isa = PBXBuildFile; productRef = FB6AF370251F7D000013B5D7 /* SwiftOTP */; };
 		FB6AF374251F7D190013B5D7 /* TrustKit in Frameworks */ = {isa = PBXBuildFile; productRef = FB6AF373251F7D190013B5D7 /* TrustKit */; };
 		FB6D7AA32448D4F300EC3176 /* VistaTerminos.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB6D7AA22448D4F300EC3176 /* VistaTerminos.swift */; };
@@ -512,13 +512,13 @@
 				6BF3785E244C107800B8080F /* libz.tbd in Frameworks */,
 				6BF3785C244C106E00B8080F /* libc++.tbd in Frameworks */,
 				FB6AF374251F7D190013B5D7 /* TrustKit in Frameworks */,
+				FB0660212524FF1B00909C5C /* ZXingObjC in Frameworks */,
 				6BF3785A244C106500B8080F /* SystemConfiguration.framework in Frameworks */,
 				6BF37858244C105A00B8080F /* CoreTelephony.framework in Frameworks */,
 				FB05B0B124452DBD00CDA0CE /* WebKit.framework in Frameworks */,
 				6BF37856244C100700B8080F /* NewRelicAgent.framework in Frameworks */,
 				510311882446376A002780C8 /* MapKit.framework in Frameworks */,
 				FB6AF371251F7D000013B5D7 /* SwiftOTP in Frameworks */,
-				51F2B361243F86E500ED16C0 /* ZXingObjC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1416,7 +1416,6 @@
 				66E41619243C094500EE4052 /* Sources */,
 				66E4161A243C094500EE4052 /* Frameworks */,
 				66E4161B243C094500EE4052 /* Resources */,
-				661C0A95244147D4001957CA /* Carhage Copy Frameworks */,
 				6BF37862244C112B00B8080F /* New Relic */,
 			);
 			buildRules = (
@@ -1427,6 +1426,7 @@
 			packageProductDependencies = (
 				FB6AF370251F7D000013B5D7 /* SwiftOTP */,
 				FB6AF373251F7D190013B5D7 /* TrustKit */,
+				FB0660202524FF1B00909C5C /* ZXingObjC */,
 			);
 			productName = CovidApp;
 			productReference = 66E4161D243C094500EE4052 /* CovidApp-Dev.app */;
@@ -1481,6 +1481,7 @@
 			packageReferences = (
 				FB6AF36F251F7D000013B5D7 /* XCRemoteSwiftPackageReference "SwiftOTP" */,
 				FB6AF372251F7D190013B5D7 /* XCRemoteSwiftPackageReference "TrustKit" */,
+				FB06601F2524FF1B00909C5C /* XCRemoteSwiftPackageReference "zxingify-objc" */,
 			);
 			productRefGroup = 66E4161E243C094500EE4052 /* Products */;
 			projectDirPath = "";
@@ -1563,26 +1564,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		661C0A95244147D4001957CA /* Carhage Copy Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/ZXingObjC.framework",
-			);
-			name = "Carhage Copy Frameworks";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ZXingObjC.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
-		};
 		6BF37862244C112B00B8080F /* New Relic */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -3016,6 +2997,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		FB06601F2524FF1B00909C5C /* XCRemoteSwiftPackageReference "zxingify-objc" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/zxingify/zxingify-objc";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 3.6.6;
+			};
+		};
 		FB6AF36F251F7D000013B5D7 /* XCRemoteSwiftPackageReference "SwiftOTP" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/lachlanbell/SwiftOTP.git";
@@ -3035,6 +3024,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		FB0660202524FF1B00909C5C /* ZXingObjC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FB06601F2524FF1B00909C5C /* XCRemoteSwiftPackageReference "zxingify-objc" */;
+			productName = ZXingObjC;
+		};
 		FB6AF370251F7D000013B5D7 /* SwiftOTP */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FB6AF36F251F7D000013B5D7 /* XCRemoteSwiftPackageReference "SwiftOTP" */;

--- a/CovidApp/CovidApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidApp/CovidApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -27,6 +27,15 @@
           "revision": "714fd3fcdcada5b107d91bf6caaaefb00f792730",
           "version": "1.6.5"
         }
+      },
+      {
+        "package": "ZXingObjC",
+        "repositoryURL": "https://github.com/zxingify/zxingify-objc",
+        "state": {
+          "branch": null,
+          "revision": "a2dbc8b38d4a35c9b784a0ee977103966ef8d909",
+          "version": "3.6.6"
+        }
       }
     ]
   },

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Más allá de las mejoras funcionales que se incorporen por requerimiento de las
 * Versión mínima de iOS: 11
 * Última versión de iOS durante el desarrollo del proyecto: 13.4
 * Versión mínima de Xcode: 11.3.1 (11C504)
-* La aplicación usa [Carthage](https://github.com/Carthage/Carthage) y [Swift Package Manager](https://swift.org/package-manager/) como sistema de manejo de dependencias. Se usan ambos ya que algunos frameworks no soportan Carthage. Para compilar el proyecto necesitás:
+* La aplicación usa [Swift Package Manager](https://swift.org/package-manager/) como sistema de manejo de dependencias. Para compilar el proyecto necesitás:
 
 ### NewRelic 
 

--- a/README.md
+++ b/README.md
@@ -57,28 +57,6 @@ Más allá de las mejoras funcionales que se incorporen por requerimiento de las
 * Para descargar y actualizar la última versión de los paquetes en la toolbar seguí estos pasos:
 File ▸ Swift Packages ▸ Update to Latest Package Versions. Esto actualizará y descargará los paquetes de los frameworks.
 
-### Carthage
-* Version mínima: 0.34.0
-* Corré el siguiente comando en la terminal dentro de `CovidApp`: `carthage update --platform iOS`
-
-Este comando clonará los repositorios especificados en el Cartfile y compilará cada dependencia generarando los frameworks. La opción `--platform iOS` asegura que los frameworks sean compilados únicamente para iOS. Si no especificás esa opción Carthage por defecto compilará para todas las plataformas que sorporten los frameworks (por ejemplo, iOS, Mac, etc.).
-
-Carthage genera el siguiente árbol de directorios:
-
-       Project Directory
-       |-- Cartfile.resolved
-       |-- Carthage
-               |-- Build
-               |-- Checkouts
-        
-`Carthage.resolved`: Este archivo define exactamente cuáles versiones fueron usadas para resolver las dependencias del proyecto.
-
-`Carthage`: Contiene 2 subdirectorios. `Build` contiene los frameworks compilados para cada dependencia.
-
-`Checkouts`: El código fuente de las dependencias que Carthage usó para compilar las dependencias y generar los frameworks.
-
-Nota: El comando `carthage bootstrap` descarga y genera los frameworks para las versiones especificadass en el archivo `Cartfile.resolved`.
-
 ## Arquitectura
 
 La app sigue el patron arquitectonico [MVP](https://en.wikipedia.org/wiki/Model–view–presenter), la capa de domain (Model) se basa en el patrón [fachada](https://en.wikipedia.org/wiki/Facade_pattern) para simplificar y unificar la manera en que los presenters acceden a la información. El proyecto tiene la capacidad de usar fachadas Mock, únicamente en debug mode y con xcode corriendo, especificando en Arguments Passed On Launch en el scheme la flag  `"com.covid.usemockfachadas"`. En este caso todas las llamadas a las fachadas simpre son exitosas y retornan mock data. Esto es útil para debugging. Si el flag está desactivado las fachadas reales son usada haciendo las llamadas de servicio reales.


### PR DESCRIPTION
Siguiendo el PR #4 este PR migra ZXingObjC a Swift Package Manager. Inicialmente la dependencia se agregó via Carthage pero ahora tiene [soporte para Swift Package Manager](https://github.com/zxingify/zxingify-objc/pull/489). También usa la url al [nuevo repositorio del proyecto](https://github.com/zxingify/zxingify-objc) ya que el [repositorio original](https://github.com/TheLevelUp/ZXingObjC) fue archivado.

ZXingObjC era la única dependencia instalada via Carthage por lo tanto fueron borrados los archivos y scripts relacionados a Carthage. La sección de instalación del Readme fue actualizada para hacer referencia solamente a Swift Package Manager. 